### PR TITLE
fix leave instruction

### DIFF
--- a/src/app/components/app/app.ts
+++ b/src/app/components/app/app.ts
@@ -37,7 +37,6 @@ section .text
 
     PUSH 5
     CALL factorial
-    POP ECX
     INT 1   ; print EAX
     HLT
 
@@ -55,7 +54,6 @@ factorial:
 
     PUSH EAX
     CALL factorial
-    POP ECX
     
     IMUL [EBP + 8]
     

--- a/src/app/emulation/instruction/retcall.ts
+++ b/src/app/emulation/instruction/retcall.ts
@@ -16,6 +16,7 @@ export class Leave extends Instruction
 {
     execute(cpu: CPU): number
     {
+        cpu.getRegisterByName("ESP").setValue(cpu.getRegisterByName("EBP").getValue());
         cpu.getRegisterByName("EBP").setValue(cpu.pop());
         return cpu.getNextInstruction();
     }


### PR DESCRIPTION
According to [Intel® 64 and IA-32 architectures software developer's manual combined volumes 2A, 2B, 2C, and 2D: Instruction set reference, A-Z](https://software.intel.com/content/www/us/en/develop/download/intel-64-and-ia-32-architectures-sdm-combined-volumes-2a-2b-2c-and-2d-instruction-set-reference-a-z.html), leave instruction should be executed as follow. but, Leave function seems to forget to copy ebp to esp.

![Screenshot from 2020-05-21 14-01-43](https://user-images.githubusercontent.com/18246032/82525142-ac22f700-9b6b-11ea-98ab-5704db2eb35d.png)

but, 